### PR TITLE
Fix exception in IsMeteredConnection

### DIFF
--- a/SharedSource/Helper.cs
+++ b/SharedSource/Helper.cs
@@ -493,6 +493,10 @@ namespace MarkerMetro.Unity.WinIntegration
 			{
 #if WINDOWS_PHONE || NETFX_CORE
 				var profile = NetworkInformation.GetInternetConnectionProfile();
+                if (profile == null)
+                {
+                    return false;
+                }
 				return profile.GetConnectionCost().NetworkCostType != NetworkCostType.Unrestricted;
 #else
                 throw new PlatformNotSupportedException("IsMeteredConnection");


### PR DESCRIPTION
A NullReferenceException was happening when calling IsMeteredConnection
when there was no connection.

Resolves: #153.
