### PR TITLE
Fix persistent Facebook login for Win8.1

### DIFF
--- a/SharedSource/Facebook/FB.cs
+++ b/SharedSource/Facebook/FB.cs
@@ -244,7 +244,7 @@ namespace MarkerMetro.Unity.WinIntegration.Facebook
                 UserName = Settings.GetString(FBNAME_KEY);
 
                 // verifies if the token has expired:
-                if (DateTime.Compare(DateTime.Now, Expires) > 0)  // < timezone?
+                if (DateTime.Compare(DateTime.UtcNow, Expires) > 0)
                     InvalidateData();
                 //var task = TestAccessToken();     
                 //task.Wait();


### PR DESCRIPTION
https://trello.com/c/rb89nZxF/223-windows-universal-win8-1-facebook-login-not-persisting
The expire time is in UTC according to this: https://github.com/facebook-csharp-sdk/facebook-csharp-sdk/blob/master/Source/Facebook/FacebookOAuthResult.cs#L123